### PR TITLE
Fix release to npm (PS-2665)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,27 @@ on: [push]
 jobs:
   build:
     runs-on: ubuntu-latest
+    outputs:
+      is_semantic_tag: ${{ steps.tag.outputs.is_semantic_tag }}
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set tag
+        id: tag
+        run: |
+          TAG="${GITHUB_REF##*/}"
+          IS_SEMANTIC_TAG=$(echo "$TAG" | grep -q '^v\?[0-9]\+\.[0-9]\+\.[0-9]\+$' && echo true || echo false)
+          echo "Tag = '$TAG', is semantic tag = '$IS_SEMANTIC_TAG'"
+          echo "::set-output name=is_semantic_tag::$IS_SEMANTIC_TAG"
+
+      - name: Install dependencies
+        run: yarn install
+
+      - name: Lint
+        run: yarn test:lint
+
+  tests:
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         node-version: [12.x, 14.x]
@@ -21,7 +42,7 @@ jobs:
         run: yarn install
 
       - name: Test
-        run: yarn run test
+        run: yarn test:unit
 
   publish:
     runs-on: ubuntu-latest

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@keboola/middy-error-logger",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Error logger middleware for Middy",
   "repository": "https://github.com/keboola/middy-error-logger",
   "author": "Jakub Matejka <jakub@keboola.com>",


### PR DESCRIPTION
Tak ještě fix podmínky pro release: https://github.com/keboola/middy-error-logger/blob/ef3399aaf199481891210ce2a8fdbedade2dc8d7/.github/workflows/ci.yml#L52 

Chybělo mi nastavit ten `is_semantic_tag` v buildu, zkopíroval jsem to z Component Generatoru (https://github.com/keboola/component-generator/blob/098cb452f537389bfc90b17298f872ec06096c4a/templates-ci/php-component/github-actions/.github/workflows/push.yml#L42-L50)

Ještě jsem teda Pipelinu rozdělil na dva kroky. V buildu se nastaví ten tag a spustí eslint a v druhým kroku už se spouští jen testy (`yarn test` byl alias pro lint i test: https://github.com/keboola/middy-error-logger/blob/f2fe2a68f04856b1b66af220fb412b2eb05eeb40/package.json#L37).